### PR TITLE
ci: use npm ci

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-node-
 
     - name: Install
-      run: npm install
+      run: npm ci
 
     - name: Build
       run: npm run build


### PR DESCRIPTION
`npm ci` is faster than `npm install`